### PR TITLE
fix: handle driver.ErrSkip to avoid duplicate hooks execution with MySQL driver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod

--- a/sqlhooks_test.go
+++ b/sqlhooks_test.go
@@ -68,62 +68,62 @@ func newSuite(t *testing.T, driver driver.Driver, dsn string) *suite {
 }
 
 func (s *suite) TestHooksExecution(t *testing.T, query string, args ...interface{}) {
-	var before, after bool
+	var beforeCount, afterCount int
 
 	s.hooks.before = func(ctx context.Context, q string, a ...interface{}) (context.Context, error) {
-		before = true
+		beforeCount++
 		return ctx, nil
 	}
 	s.hooks.after = func(ctx context.Context, q string, a ...interface{}) (context.Context, error) {
-		after = true
+		afterCount++
 		return ctx, nil
 	}
 
 	t.Run("Query", func(t *testing.T) {
-		before, after = false, false
+		beforeCount, afterCount = 0, 0
 		_, err := s.db.Query(query, args...)
 		require.NoError(t, err)
-		assert.True(t, before, "Before Hook did not run for query: "+query)
-		assert.True(t, after, "After Hook did not run for query:  "+query)
+		assert.Equal(t, 1, beforeCount, "Before Hook didn't execute only once: "+query)
+		assert.Equal(t, 1, afterCount, "After Hook didn't execute only once: "+query)
 	})
 
 	t.Run("QueryContext", func(t *testing.T) {
-		before, after = false, false
+		beforeCount, afterCount = 0, 0
 		_, err := s.db.QueryContext(context.Background(), query, args...)
 		require.NoError(t, err)
-		assert.True(t, before, "Before Hook did not run for query: "+query)
-		assert.True(t, after, "After Hook did not run for query:  "+query)
+		assert.Equal(t, 1, beforeCount, "Before Hook didn't execute only once: "+query)
+		assert.Equal(t, 1, afterCount, "After Hook didn't execute only once: "+query)
 	})
 
 	t.Run("Exec", func(t *testing.T) {
-		before, after = false, false
+		beforeCount, afterCount = 0, 0
 		_, err := s.db.Exec(query, args...)
 		require.NoError(t, err)
-		assert.True(t, before, "Before Hook did not run for query: "+query)
-		assert.True(t, after, "After Hook did not run for query:  "+query)
+		assert.Equal(t, 1, beforeCount, "Before Hook didn't execute only once: "+query)
+		assert.Equal(t, 1, afterCount, "After Hook didn't execute only once: "+query)
 	})
 
 	t.Run("ExecContext", func(t *testing.T) {
-		before, after = false, false
+		beforeCount, afterCount = 0, 0
 		_, err := s.db.ExecContext(context.Background(), query, args...)
 		require.NoError(t, err)
-		assert.True(t, before, "Before Hook did not run for query: "+query)
-		assert.True(t, after, "After Hook did not run for query:  "+query)
+		assert.Equal(t, 1, beforeCount, "Before Hook didn't execute only once: "+query)
+		assert.Equal(t, 1, afterCount, "After Hook didn't execute only once: "+query)
 	})
 
 	t.Run("Statements", func(t *testing.T) {
-		before, after = false, false
+		beforeCount, afterCount = 0, 0
 		stmt, err := s.db.Prepare(query)
 		require.NoError(t, err)
 
 		// Hooks just run when the stmt is executed (Query or Exec)
-		assert.False(t, before, "Before Hook run before execution: "+query)
-		assert.False(t, after, "After Hook run before execution:  "+query)
+		assert.Equal(t, 0, beforeCount, "Before Hook run before execution: "+query)
+		assert.Equal(t, 0, afterCount, "After Hook run before execution:  "+query)
 
 		_, err = stmt.Query(args...)
 		require.NoError(t, err)
-		assert.True(t, before, "Before Hook did not run for query: "+query)
-		assert.True(t, after, "After Hook did not run for query:  "+query)
+		assert.Equal(t, 1, beforeCount, "Before Hook didn't execute only once: "+query)
+		assert.Equal(t, 1, afterCount, "After Hook didn't execute only once: "+query)
 	})
 }
 


### PR DESCRIPTION
## Fix duplicate hooks execution with MySQL driver when InterpolateParams=false

### Problem
When the MySQL driver is configured with `InterpolateParams=false` (default value), it returns `driver.ErrSkip` which causes the SQL package to fall back to using prepared statements. This results in hooks being executed twice for a single logical operation:
1. First time: Before + OnError (with driver.ErrSkip)
2. Second time: Before + After/OnError for the actual query execution

This double execution of hooks is unexpected and can lead to issues such as duplicate logging, metrics, or other side effects.

### Solution
This change handles `driver.ErrSkip` internally by adding special handling in the hook execution flow, ensuring that hooks are only executed once per logical operation, even when the MySQL driver returns `driver.ErrSkip`.

### Implementation
- Refactored code to extract `execWithHooks` and `queryWithHooks` helper functions for cleaner code organization
- Added special handling for `driver.ErrSkip` to prevent duplicate hook executions
- Added appropriate error handling to maintain compatibility with the SQL package's behavior

### Test Changes
- Modified the test suite to count hook executions instead of simply checking if they ran
- Added assertions to verify hooks are executed exactly once per operation

### Related Issues
This fixes a long-standing issue that has been reported multiple times:
- https://github.com/qustavo/sqlhooks/issues/38
- https://github.com/qustavo/sqlhooks/issues/32
- https://github.com/qustavo/sqlhooks/issues/52 